### PR TITLE
Switching from CI develop branch to 3.0-stable

### DIFF
--- a/rr3-admin/source/important.rst
+++ b/rr3-admin/source/important.rst
@@ -1,6 +1,16 @@
 Important changes
 ****************
 
+* 2015/12/17
+
+  Please, don't use CodeIgniter's develop branch anymore and preferably switch to "3.0-stable" branch instead. Recent develop branch (as of 17 December 2015) breaks local authentication. If you're using develop branch, switching to 3.0-stable may be achieved by the following code if you installed CodeIgniter into :code:`/opt/codeigniter` directory:
+
+  .. code:: bash
+
+    cd /opt/codeigniter
+    git checkout -b 3.0-stable origin/3.0-stable
+    git pull
+
 * 2015/02/25
   Since now Doctrine, Zend-ACL is loaded via autoloader. 
 

--- a/rr3-admin/source/installation.rst
+++ b/rr3-admin/source/installation.rst
@@ -38,16 +38,15 @@ Requirements
 Download JAGGER and Codeigniter
 ===============================
 
-In the time writting this document there wasn't official release of Codeigniter version 3.0.
-So we are going to use source code from GitHub repository
+We are going to use source code from GitHub repository. Using 3.0-stable branch is preferred as develop branch sometimes doesn't work properly.
 
- .. note:: we will be using develop branch 
+ .. note:: we will be using 3.0-stable branch
 
 .. code:: bash
 
  git clone git://github.com/bcit-ci/CodeIgniter.git /opt/codeigniter
  cd /opt/codeigniter
- git checkout -b develop origin/develop 
+ git checkout -b 3.0-stable origin/3.0-stable
  git pull
 
 JAGGER (ResourceRegistry3) is published on GITHUB https://github.com/Edugate/Jagger  under MIT License.


### PR DESCRIPTION
Recent CI develop branch breaks local authentication, so it's
recommendable to move to 3.0-stable.

"Installation process" and "Important changes" have been altered.